### PR TITLE
[WIP] Fix PPC64 target

### DIFF
--- a/examples/Nat.sfw
+++ b/examples/Nat.sfw
@@ -4,7 +4,7 @@ type T =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/examples/Nat.sfw
+++ b/examples/Nat.sfw
@@ -4,7 +4,7 @@ type T =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/examples/NativeFact.sfw
+++ b/examples/NativeFact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "puts" println : Bytes -[IO]-> Unit
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 let printInt (n : Int) =
   let buf = alloc 512 in

--- a/examples/NativeFact.sfw
+++ b/examples/NativeFact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "puts" println : Bytes -[IO]-> Unit
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 let printInt (n : Int) =
   let buf = alloc 512 in

--- a/src/backend/backend.ml
+++ b/src/backend/backend.ml
@@ -391,7 +391,7 @@ module Make (I : I) = struct
         let args = try Array.sub args 0 idx with Invalid_argument _ -> assert false in
         Llvm.var_arg_function_type ret args
 
-   let rec create_results ~last_bind ~jmp_buf ~next_block vars env builder =
+  let rec create_results ~last_bind ~jmp_buf ~next_block vars env builder =
     let aux (env, results) result =
       let (block, builder') = Llvm.create_block c builder in
       let env = load_vars builder' env vars in
@@ -607,8 +607,9 @@ let get_triple () =
 
 let get_target ~triple =
   let target = Llvm_target.Target.by_triple triple in
-  let reloc_mode = Llvm_target.RelocMode.PIC in
-  Llvm_target.TargetMachine.create ~triple ~reloc_mode target
+  let reloc_mode = Llvm_target.RelocMode.PIC in (* TODO: Is this really what i want? *)
+  let level = Llvm_target.CodeGenOptLevel.Default in (* TODO: This is -O2. Make it dependent on options#opt instead *)
+  Llvm_target.TargetMachine.create ~triple ~reloc_mode ~level target
 
 let privatize_identifiers m =
   let aux f v =

--- a/src/desugaring/DesugaredTreePrinter.ml
+++ b/src/desugaring/DesugaredTreePrinter.ml
@@ -172,7 +172,7 @@ let dump_instance name tyclass =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
+  | Some (_loc, va_arg) -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let dump_top = function
   | Value x ->

--- a/src/desugaring/DesugaredTreePrinter.ml
+++ b/src/desugaring/DesugaredTreePrinter.ml
@@ -172,7 +172,7 @@ let dump_instance name tyclass =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let dump_top = function
   | Value x ->
@@ -180,7 +180,7 @@ let dump_top = function
   | Type (name, ty) ->
       str "type alias" ^^^ dump_ty_name name ^^^ equals ^//^ dump_ty ty
   | Foreign (cname, options, name, ty) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
+      str "foreign" ^^^ dump_foreign_options options ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
       dump_ty ty
   | Datatype (name, k, variants) ->
       str "type" ^^^ dump_ty_name name ^^^ colon ^^^ dump_kind k ^^^ equals ^//^

--- a/src/desugaring/DesugaredTreePrinter.ml
+++ b/src/desugaring/DesugaredTreePrinter.ml
@@ -169,13 +169,18 @@ let dump_class name params =
 let dump_instance name tyclass =
   dump_instance_name name ^^^ dump_tyclass_instance tyclass
 
+let dump_foreign_options {va_arg} =
+  match va_arg with
+  | None -> empty
+  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+
 let dump_top = function
   | Value x ->
       dump_let ~is_rec:false x
   | Type (name, ty) ->
       str "type alias" ^^^ dump_ty_name name ^^^ equals ^//^ dump_ty ty
-  | Foreign (cname, name, ty) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
+  | Foreign (cname, options, name, ty) ->
+      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
       dump_ty ty
   | Datatype (name, k, variants) ->
       str "type" ^^^ dump_ty_name name ^^^ colon ^^^ dump_kind k ^^^ equals ^//^

--- a/src/desugaring/desugaredTree.mli
+++ b/src/desugaring/desugaredTree.mli
@@ -11,7 +11,7 @@ type module_name = Module.t
 type loc = Location.t
 
 type foreign_options = {
-  va_arg : index option;
+  va_arg : (loc * index) option;
 }
 
 type kind = ParseTree.kind =

--- a/src/desugaring/desugaredTree.mli
+++ b/src/desugaring/desugaredTree.mli
@@ -1,6 +1,7 @@
 (* Copyright (c) 2013-2017 The Labrys developers. *)
 (* See the LICENSE file at the top-level directory. *)
 
+type index = int
 type name = Ident.Name.t
 type constr_name = Ident.Constr.t
 type t_name = Ident.Type.t
@@ -8,6 +9,10 @@ type tyclass_name = Ident.TyClass.t
 type instance_name = Ident.Instance.t
 type module_name = Module.t
 type loc = Location.t
+
+type foreign_options = {
+  va_arg : index option;
+}
 
 type kind = ParseTree.kind =
   | KStar
@@ -76,7 +81,7 @@ type variant = (constr_name * ty)
 type top =
   | Value of (name * t)
   | Type of (t_name * ty)
-  | Foreign of (string * name * ty)
+  | Foreign of (string * foreign_options * name * ty)
   | Datatype of (t_name * kind * variant list)
   | Exception of (constr_name * ty)
   | Class of (tyclass_name * t_value list * (name * ty) list)

--- a/src/flatten/FlattenTreePrinter.ml
+++ b/src/flatten/FlattenTreePrinter.ml
@@ -51,7 +51,7 @@ let dump_foreign_ty args ret =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let rec dump_branch t =
   bar ^^^ dump_t t

--- a/src/flatten/FlattenTreePrinter.ml
+++ b/src/flatten/FlattenTreePrinter.ml
@@ -48,6 +48,11 @@ let dump_args_ty args =
 let dump_foreign_ty args ret =
   dump_args_ty args ^^^ str "->" ^^^ dump_tag_ty ret
 
+let dump_foreign_options {va_arg} =
+  match va_arg with
+  | None -> empty
+  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+
 let rec dump_branch t =
   bar ^^^ dump_t t
 
@@ -60,8 +65,8 @@ and dump_t' = function
       dump_name name
   | Datatype (rep, args) ->
       dump_list (dump_constr_rep_opt rep @ List.map dump_name args)
-  | CallForeign (name, ret, args) ->
-      str "Call" ^^^ parens (str name ^^^ colon ^^^ dump_foreign_ty args ret)
+  | CallForeign (name, options, ret, args) ->
+      str "Call" ^^^ dump_foreign_options options ^^^ parens (str name ^^^ colon ^^^ dump_foreign_ty args ret)
   | PatternMatching (t, vars, branches, tree) ->
       str "match" ^^^ dump_name t ^^^ str "with" ^/^
       braces (separate_map space dump_name vars) ^^^ str "in" ^/^

--- a/src/flatten/FlattenTreePrinter.ml
+++ b/src/flatten/FlattenTreePrinter.ml
@@ -51,7 +51,7 @@ let dump_foreign_ty args ret =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
+  | Some (_loc, va_arg) -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let rec dump_branch t =
   bar ^^^ dump_t t

--- a/src/flatten/flatten.ml
+++ b/src/flatten/flatten.ml
@@ -28,8 +28,8 @@ let rec propagate' env = function
       ([], Val name)
   | Datatype (idx, args) ->
       ([], Datatype (idx, args))
-  | CallForeign (name, ret, args) ->
-      ([], CallForeign (name, ret, args))
+  | CallForeign (name, options, ret, args) ->
+      ([], CallForeign (name, options, ret, args))
   | PatternMatching (name, vars, branches, tree) ->
       let name = rename env name in
       let branches = List.map (propagate env) branches in
@@ -77,8 +77,8 @@ let rec of_term = function
       ([], Val name)
   | LambdaTree.Datatype (idx, args) ->
       ([], Datatype (idx, args))
-  | LambdaTree.CallForeign (name, ret, args) ->
-      ([], CallForeign (name, ret, args))
+  | LambdaTree.CallForeign (name, options, ret, args) ->
+      ([], CallForeign (name, options, ret, args))
   | LambdaTree.PatternMatching (name, vars, branches, tree) ->
       let branches = List.map of_term branches in
       ([], PatternMatching (name, vars, branches, tree))

--- a/src/flatten/flattenTree.mli
+++ b/src/flatten/flattenTree.mli
@@ -6,9 +6,10 @@ type index = int
 type constr = int
 type length = int
 type branch = int
+type loc = Location.t
 
 type foreign_options = LambdaTree.foreign_options = {
-  va_arg : index option;
+  va_arg : (loc * index) option;
 }
 
 type ('int, 'float, 'char, 'bytes) ty =

--- a/src/flatten/flattenTree.mli
+++ b/src/flatten/flattenTree.mli
@@ -7,6 +7,10 @@ type constr = int
 type length = int
 type branch = int
 
+type foreign_options = LambdaTree.foreign_options = {
+  va_arg : index option;
+}
+
 type ('int, 'float, 'char, 'bytes) ty =
   ('int, 'float, 'char, 'bytes) LambdaTree.ty
 
@@ -27,7 +31,7 @@ type t' =
   | App of (name * name)
   | Val of name
   | Datatype of (constr_rep option * name list)
-  | CallForeign of (string * ret_ty * (tag_ty * name) list)
+  | CallForeign of (string * foreign_options * ret_ty * (tag_ty * name) list)
   | PatternMatching of (name * name list * t list * tree)
   | Fail of name
   | Try of (t * (name * t))

--- a/src/lambda/LambdaTreePrinter.ml
+++ b/src/lambda/LambdaTreePrinter.ml
@@ -48,6 +48,11 @@ let dump_args_ty args =
 let dump_foreign_ty args ret =
   dump_args_ty args ^^^ str "->" ^^^ dump_tag_ty ret
 
+let dump_foreign_options {va_arg} =
+  match va_arg with
+  | None -> empty
+  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+
 let rec dump_let (name, is_rec, t) =
   let r = if is_rec then space ^^ str "rec" else empty in
   str "let" ^^ r ^^^ dump_name name ^^^ equals ^//^ dump_t t
@@ -64,8 +69,8 @@ and dump_t = function
       dump_name name
   | Datatype (rep, args) ->
       dump_list (dump_constr_rep_opt rep @ List.map dump_name args)
-  | CallForeign (name, ret, args) ->
-      str "Call" ^^^ parens (str name ^^^ colon ^^^ dump_foreign_ty args ret)
+  | CallForeign (name, options, ret, args) ->
+      str "Call" ^^^ dump_foreign_options options ^^^ parens (str name ^^^ colon ^^^ dump_foreign_ty args ret)
   | PatternMatching (t, vars, branches, tree) ->
       str "match" ^^^ dump_name t ^^^ str "with" ^/^
       braces (separate_map space dump_name vars) ^^^ str "in" ^/^

--- a/src/lambda/LambdaTreePrinter.ml
+++ b/src/lambda/LambdaTreePrinter.ml
@@ -51,7 +51,7 @@ let dump_foreign_ty args ret =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let rec dump_let (name, is_rec, t) =
   let r = if is_rec then space ^^ str "rec" else empty in

--- a/src/lambda/LambdaTreePrinter.ml
+++ b/src/lambda/LambdaTreePrinter.ml
@@ -51,7 +51,7 @@ let dump_foreign_ty args ret =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
+  | Some (_loc, va_arg) -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let rec dump_let (name, is_rec, t) =
   let r = if is_rec then space ^^ str "rec" else empty in

--- a/src/lambda/lambda.ml
+++ b/src/lambda/lambda.ml
@@ -163,7 +163,7 @@ and of_typed_term env = function
   | UntypedTree.Const const ->
       Const const
 
-let create_dyn_functions cname (ret, args) =
+let create_dyn_functions cname options (ret, args) =
   match args with
   | [] ->
       (* TODO: See TypeChecker.get_foreign_type *)
@@ -175,7 +175,7 @@ let create_dyn_functions cname (ret, args) =
             let t = aux ((ty, name) :: args) (succ n) xs in
             Abs (name, t)
         | [] ->
-            CallForeign (cname, ret, List.rev args)
+            CallForeign (cname, options, ret, List.rev args)
       in
       let name = LIdent.create (string_of_int 0) in
       let t = aux [(ty, name)] 1 args in
@@ -197,10 +197,10 @@ let rec of_typed_tree mset env = function
       let (name, mset, env, linkage) = env_add mset name env in
       let xs = of_typed_tree mset env xs in
       Value (name, t, linkage) :: xs
-  | UntypedTree.Foreign (cname, name, ty) :: xs ->
+  | UntypedTree.Foreign (cname, options, name, ty) :: xs ->
       let (name, mset, env, linkage) = env_add mset name env in
       let xs = of_typed_tree mset env xs in
-      Value (name, create_dyn_functions cname ty, linkage) :: xs
+      Value (name, create_dyn_functions cname options ty, linkage) :: xs
   | UntypedTree.Exception name :: xs ->
       let (name, mset, env, _) = env_add mset name env in
       let xs = of_typed_tree mset env xs in
@@ -219,7 +219,7 @@ let rec of_typed_tree mset env = function
 
 let rec scan mset = function
   | UntypedTree.Value (name, _) :: xs
-  | UntypedTree.Foreign (_, name, _) :: xs
+  | UntypedTree.Foreign (_, _, name, _) :: xs
   | UntypedTree.Instance (name, _) :: xs ->
       scan (Set.add mset name) xs
   | UntypedTree.Exception _ :: xs ->

--- a/src/lambda/lambdaTree.mli
+++ b/src/lambda/lambdaTree.mli
@@ -7,9 +7,10 @@ type constr = int
 type length = int
 type branch = int
 type is_rec = bool
+type loc = Location.t
 
 type foreign_options = UntypedTree.foreign_options = {
-  va_arg : index option;
+  va_arg : (loc * index) option;
 }
 
 type ('int, 'float, 'char, 'bytes) ty =

--- a/src/lambda/lambdaTree.mli
+++ b/src/lambda/lambdaTree.mli
@@ -8,6 +8,10 @@ type length = int
 type branch = int
 type is_rec = bool
 
+type foreign_options = UntypedTree.foreign_options = {
+  va_arg : index option;
+}
+
 type ('int, 'float, 'char, 'bytes) ty =
   ('int, 'float, 'char, 'bytes) UntypedTree.ty
 
@@ -28,7 +32,7 @@ type t =
   | App of (name * name)
   | Val of name
   | Datatype of (constr_rep option * name list)
-  | CallForeign of (string * ret_ty * (tag_ty * name) list)
+  | CallForeign of (string * foreign_options * ret_ty * (tag_ty * name) list)
   | PatternMatching of (name * name list * t list * tree)
   | Let of (name * is_rec * t * t)
   | Fail of name

--- a/src/optimization/OptimizedTreePrinter.ml
+++ b/src/optimization/OptimizedTreePrinter.ml
@@ -51,6 +51,11 @@ let dump_foreign_ty args ret =
 let dump_fv fv =
   dump_list (List.map dump_name (LIdent.MSet.to_list fv))
 
+let dump_foreign_options {va_arg} =
+  match va_arg with
+  | None -> empty
+  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+
 let rec dump_branch t =
   bar ^^^ dump_t t
 
@@ -63,8 +68,8 @@ and dump_t' = function
       dump_name name
   | Datatype (rep, args) ->
       dump_list (dump_constr_rep_opt rep @ List.map dump_name args)
-  | CallForeign (name, ret, args) ->
-      str "Call" ^^^ parens (str name ^^^ colon ^^^ dump_foreign_ty args ret)
+  | CallForeign (name, options, ret, args) ->
+      str "Call" ^^^ dump_foreign_options options ^^^ parens (str name ^^^ colon ^^^ dump_foreign_ty args ret)
   | PatternMatching (t, vars, branches, tree) ->
       str "match" ^^^ dump_name t ^^^ str "with" ^/^
       braces (separate_map space dump_name vars) ^^^ str "in" ^/^

--- a/src/optimization/OptimizedTreePrinter.ml
+++ b/src/optimization/OptimizedTreePrinter.ml
@@ -54,7 +54,7 @@ let dump_fv fv =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
+  | Some (_loc, va_arg) -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let rec dump_branch t =
   bar ^^^ dump_t t

--- a/src/optimization/OptimizedTreePrinter.ml
+++ b/src/optimization/OptimizedTreePrinter.ml
@@ -54,7 +54,7 @@ let dump_fv fv =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let rec dump_branch t =
   bar ^^^ dump_t t

--- a/src/optimization/optimize.ml
+++ b/src/optimization/optimize.ml
@@ -16,9 +16,9 @@ let rec of_term' = function
       (Val name, Set.singleton name)
   | FlattenTree.Datatype (idx, args) ->
       (Datatype (idx, args), Set.of_list args)
-  | FlattenTree.CallForeign (name, ty, args) ->
+  | FlattenTree.CallForeign (name, options, ty, args) ->
       let fv = List.fold_right (fun (_, name) fv -> Set.add fv name) args Set.empty in
-      (CallForeign (name, ty, args), fv)
+      (CallForeign (name, options, ty, args), fv)
   | FlattenTree.PatternMatching (name, vars, branches, tree) ->
       let (branches, fv) = of_branches branches in
       let fv = List.fold_left Set.remove_all fv vars in
@@ -66,6 +66,7 @@ and of_branches branches =
 
 let of_flatten_tree tree =
   let aux = function
+    (* TODO: OptimizedTree.Function is unused *)
     | FlattenTree.Value (name, t, linkage) ->
         let (t, _) = of_term t in
         Value (name, t, linkage)

--- a/src/optimization/optimizedTree.mli
+++ b/src/optimization/optimizedTree.mli
@@ -8,6 +8,10 @@ type constr = int
 type length = int
 type branch = int
 
+type foreign_options = FlattenTree.foreign_options = {
+  va_arg : index option;
+}
+
 type ('int, 'float, 'char, 'bytes) ty =
   ('int, 'float, 'char, 'bytes) FlattenTree.ty
 
@@ -28,7 +32,7 @@ type t' =
   | App of (name * name)
   | Val of name
   | Datatype of (constr_rep option * name list)
-  | CallForeign of (string * ret_ty * (tag_ty * name) list)
+  | CallForeign of (string * foreign_options * ret_ty * (tag_ty * name) list)
   | PatternMatching of (name * name list * t list * tree)
   | Fail of name
   | Try of (t * (name * t))

--- a/src/optimization/optimizedTree.mli
+++ b/src/optimization/optimizedTree.mli
@@ -7,9 +7,10 @@ type index = int
 type constr = int
 type length = int
 type branch = int
+type loc = Location.t
 
 type foreign_options = FlattenTree.foreign_options = {
-  va_arg : index option;
+  va_arg : (loc * index) option;
 }
 
 type ('int, 'float, 'char, 'bytes) ty =

--- a/src/parsing/ParseTreePrinter.ml
+++ b/src/parsing/ParseTreePrinter.ml
@@ -192,13 +192,17 @@ let dump_class name params =
 let dump_instance name tyclass =
   dump_instance_name name ^^^ dump_tyclass_instance tyclass
 
+let rec dump_foreign_options = function
+  | [] -> empty
+  | (name, arg)::xs -> dump_name name ^^ str "(" ^^ str arg ^^ str ")" ^^^ dump_foreign_options xs
+
 let dump_top = function
   | Value x ->
       dump_let x
   | Type (name, ty) ->
       str "type alias" ^^^ dump_name name ^^^ equals ^//^ dump_ty ty
-  | Foreign (cname, name, ty) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
+  | Foreign (cname, options, name, ty) ->
+      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
       dump_ty ty
   | AbstractType (name, k) ->
       str "type" ^^^ dump_name name ^^^ dump_kind_opt k

--- a/src/parsing/parseTree.mli
+++ b/src/parsing/parseTree.mli
@@ -9,6 +9,8 @@ type new_upper_name = (loc * [`NewUpperName of string])
 type lower_name = (loc * [`LowerName of string list])
 type upper_name = (loc * [`UpperName of string list])
 
+type foreign_options = (new_lower_name * string) list
+
 type kind =
   | KStar
   | KEff
@@ -96,7 +98,7 @@ type top =
   | Value of value
   | Type of (new_upper_name * ty)
   | AbstractType of (new_upper_name * kind option)
-  | Foreign of (char list * new_lower_name * ty)
+  | Foreign of (char list * foreign_options * new_lower_name * ty)
   | Datatype of (new_upper_name * ty_arg list * variant list)
   | Exception of (new_upper_name * ty list)
   | Open of import

--- a/src/parsing/parser.mly
+++ b/src/parsing/parser.mly
@@ -75,8 +75,8 @@ body:
       { ParseTree.Value x }
   | typeAlias = typeAlias
       { ParseTree.Type typeAlias }
-  | Foreign cname = String name = newLowerName Colon ty = typeExpr
-      { ParseTree.Foreign (cname, name, ty) }
+  | Foreign options = foreign_options cname = String name = newLowerName Colon ty = typeExpr
+      { ParseTree.Foreign (cname, options, name, ty) }
   | Type name = newUpperName k = kindopt
       { ParseTree.AbstractType (name, k) }
   | datatype = datatype
@@ -89,6 +89,10 @@ body:
       { ParseTree.Class (name, params, sigs) }
   | Instance name = instanceName x = tyclassInstance Equal values = let_case+ End
       { ParseTree.Instance (x, name, values) }
+
+foreign_options:
+  | { [] }
+  | name = newLowerName LParen va_arg = Int RParen { [(name, va_arg)] }
 
 instanceName:
   | { None }

--- a/src/pre-typing/PretypedTreePrinter.ml
+++ b/src/pre-typing/PretypedTreePrinter.ml
@@ -172,7 +172,7 @@ let dump_instance name tyclass =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
+  | Some (_loc, va_arg) -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let dump_top = function
   | Value x ->

--- a/src/pre-typing/PretypedTreePrinter.ml
+++ b/src/pre-typing/PretypedTreePrinter.ml
@@ -172,7 +172,7 @@ let dump_instance name tyclass =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let dump_top = function
   | Value x ->
@@ -180,7 +180,7 @@ let dump_top = function
   | Type (name, ty) ->
       str "type alias" ^^^ dump_ty_name name ^^^ equals ^//^ dump_ty ty
   | Foreign (cname, options, name, ty) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
+      str "foreign" ^^^ dump_foreign_options options ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
       dump_ty ty
   | Datatype (name, k, variants) ->
       str "type" ^^^ dump_ty_name name ^^^ colon ^^^ dump_kind k ^^^ equals ^//^

--- a/src/pre-typing/PretypedTreePrinter.ml
+++ b/src/pre-typing/PretypedTreePrinter.ml
@@ -169,13 +169,18 @@ let dump_class name params =
 let dump_instance name tyclass =
   dump_instance_name name ^^^ dump_tyclass_instance tyclass
 
+let dump_foreign_options {va_arg} =
+  match va_arg with
+  | None -> empty
+  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+
 let dump_top = function
   | Value x ->
       dump_let x
   | Type (name, ty) ->
       str "type alias" ^^^ dump_ty_name name ^^^ equals ^//^ dump_ty ty
-  | Foreign (cname, name, ty) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
+  | Foreign (cname, options, name, ty) ->
+      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
       dump_ty ty
   | Datatype (name, k, variants) ->
       str "type" ^^^ dump_ty_name name ^^^ colon ^^^ dump_kind k ^^^ equals ^//^

--- a/src/pre-typing/pretypedTree.mli
+++ b/src/pre-typing/pretypedTree.mli
@@ -8,6 +8,11 @@ type tyclass_name = Ident.TyClass.t
 type instance_name = Ident.Instance.t
 type module_name = Module.t
 type loc = Location.t
+type index = int
+
+type foreign_options = DesugaredTree.foreign_options = {
+  va_arg : index option;
+}
 
 type kind = DesugaredTree.kind =
   | KStar
@@ -76,7 +81,7 @@ type variant = (constr_name * ty)
 type top =
   | Value of (name * t)
   | Type of (t_name * ty)
-  | Foreign of (string * name * ty)
+  | Foreign of (string * foreign_options * name * ty)
   | Datatype of (t_name * kind * variant list)
   | Exception of (constr_name * ty)
   | Class of (tyclass_name * t_value list * (name * ty) list)

--- a/src/pre-typing/pretypedTree.mli
+++ b/src/pre-typing/pretypedTree.mli
@@ -11,7 +11,7 @@ type loc = Location.t
 type index = int
 
 type foreign_options = DesugaredTree.foreign_options = {
-  va_arg : index option;
+  va_arg : (loc * index) option;
 }
 
 type kind = DesugaredTree.kind =

--- a/src/typing/UntypedTree.mli
+++ b/src/typing/UntypedTree.mli
@@ -7,6 +7,10 @@ type index = int
 type length = int
 type branch = int
 
+type foreign_options = PretypedTree.foreign_options = {
+  va_arg : index option;
+}
+
 type ('int, 'float, 'char, 'bytes) ty = [
   | `Int of 'int
   | `Float of 'float
@@ -45,6 +49,6 @@ type foreign_fun_type = (ret_ty * tag_ty list)
 
 type top =
   | Value of (name * t)
-  | Foreign of (string * name * foreign_fun_type)
+  | Foreign of (string * foreign_options * name * foreign_fun_type)
   | Exception of name
   | Instance of (name * (name * t) list)

--- a/src/typing/UntypedTree.mli
+++ b/src/typing/UntypedTree.mli
@@ -6,9 +6,10 @@ type pat_vars = Ident.Name.Set.t
 type index = int
 type length = int
 type branch = int
+type loc = Location.t
 
 type foreign_options = PretypedTree.foreign_options = {
-  va_arg : index option;
+  va_arg : (loc * index) option;
 }
 
 type ('int, 'float, 'char, 'bytes) ty = [

--- a/src/typing/UntypedTreePrinter.ml
+++ b/src/typing/UntypedTreePrinter.ml
@@ -107,7 +107,7 @@ let dump_args_ty args =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
+  | Some (_loc, va_arg) -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let dump_top = function
   | Value x ->

--- a/src/typing/UntypedTreePrinter.ml
+++ b/src/typing/UntypedTreePrinter.ml
@@ -104,11 +104,16 @@ let dump_tag_ty = function
 let dump_args_ty args =
   dump_list (List.map dump_tag_ty args)
 
+let dump_foreign_options {va_arg} =
+  match va_arg with
+  | None -> empty
+  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+
 let dump_top = function
   | Value x ->
       dump_let x
-  | Foreign (cname, name, (ret, args)) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
+  | Foreign (cname, options, name, (ret, args)) ->
+      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
       dump_args_ty args ^^^ str "->" ^^^ dump_tag_ty ret
   | Exception name ->
       str "exception" ^^^ dump_name name

--- a/src/typing/UntypedTreePrinter.ml
+++ b/src/typing/UntypedTreePrinter.ml
@@ -107,13 +107,13 @@ let dump_args_ty args =
 let dump_foreign_options {va_arg} =
   match va_arg with
   | None -> empty
-  | Some va_arg -> str "va_arg(" ^^^ OCaml.int va_arg ^^^ str ")"
+  | Some va_arg -> str "va_arg(" ^^ OCaml.int va_arg ^^ str ")"
 
 let dump_top = function
   | Value x ->
       dump_let x
   | Foreign (cname, options, name, (ret, args)) ->
-      str "foreign" ^^^ dump_cname cname ^^^ dump_foreign_options options ^^^ dump_name name ^^^ colon ^//^
+      str "foreign" ^^^ dump_foreign_options options ^^^ dump_cname cname ^^^ dump_name name ^^^ colon ^//^
       dump_args_ty args ^^^ str "->" ^^^ dump_tag_ty ret
   | Exception name ->
       str "exception" ^^^ dump_name name

--- a/src/typing/typeChecker.ml
+++ b/src/typing/typeChecker.ml
@@ -453,12 +453,12 @@ let check_top ~current_module options (acc, has_main, env) = function
   | PretypedTree.Type (name, ty) ->
       let env = Env.add_type_alias name ty env in
       (acc, has_main, env)
-  | PretypedTree.Foreign (cname, name, ty) ->
+  | PretypedTree.Foreign (cname, foreign_options, name, ty) ->
       let ty = NType.check ~pure_arrow:`Allow env ty in
       let rty =
         check_foreign_type ~loc:(Ident.Name.loc name) options env (NType.monomorphic_split ty)
       in
-      let acc = acc @ [Foreign (cname, name, rty)] in
+      let acc = acc @ [Foreign (cname, foreign_options, name, rty)] in
       let env = Env.add_value name ty env in
       (acc, has_main, env)
   | PretypedTree.Datatype (name, k, variants) ->

--- a/tests/old-examples/Bug.sfw
+++ b/tests/old-examples/Bug.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Bug.sfw
+++ b/tests/old-examples/Bug.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/ExnVar.sfw
+++ b/tests/old-examples/ExnVar.sfw
@@ -8,7 +8,7 @@ exception EndOfFile
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/ExnVar.sfw
+++ b/tests/old-examples/ExnVar.sfw
@@ -8,7 +8,7 @@ exception EndOfFile
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Fact.sfw
+++ b/tests/old-examples/Fact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Fact.sfw
+++ b/tests/old-examples/Fact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/GrosGrosBug.sfw
+++ b/tests/old-examples/GrosGrosBug.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/GrosGrosBug.sfw
+++ b/tests/old-examples/GrosGrosBug.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/LetRecIn.sfw
+++ b/tests/old-examples/LetRecIn.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/LetRecIn.sfw
+++ b/tests/old-examples/LetRecIn.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Nat.sfw
+++ b/tests/old-examples/Nat.sfw
@@ -4,7 +4,7 @@ type T =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Nat.sfw
+++ b/tests/old-examples/Nat.sfw
@@ -4,7 +4,7 @@ type T =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/NativeFact.sfw
+++ b/tests/old-examples/NativeFact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "puts" println : Bytes -[IO]-> Unit
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 let printInt (n : Int) =
   let buf = alloc 512 in

--- a/tests/old-examples/NativeFact.sfw
+++ b/tests/old-examples/NativeFact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "puts" println : Bytes -[IO]-> Unit
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 let printInt (n : Int) =
   let buf = alloc 512 in

--- a/tests/old-examples/Print.sfw
+++ b/tests/old-examples/Print.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Print.sfw
+++ b/tests/old-examples/Print.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Rec.sfw
+++ b/tests/old-examples/Rec.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Rec.sfw
+++ b/tests/old-examples/Rec.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/SystemF.sfw
+++ b/tests/old-examples/SystemF.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/SystemF.sfw
+++ b/tests/old-examples/SystemF.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/SystemFOmega.sfw
+++ b/tests/old-examples/SystemFOmega.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/SystemFOmega.sfw
+++ b/tests/old-examples/SystemFOmega.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/TailFact.sfw
+++ b/tests/old-examples/TailFact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/TailFact.sfw
+++ b/tests/old-examples/TailFact.sfw
@@ -6,7 +6,7 @@ type alias Nat = Nat.T
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Test.sfw
+++ b/tests/old-examples/Test.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 

--- a/tests/old-examples/Test.sfw
+++ b/tests/old-examples/Test.sfw
@@ -4,7 +4,7 @@ type Nat =
 
 foreign "GC_malloc" alloc : Int -[IO]-> Bytes
 
-foreign "sprintf/2" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
+foreign va_arg(2) "sprintf" fmt : Bytes -> Bytes -> Int -[IO]-> Unit
 
 foreign "puts" println : Bytes -[IO]-> Unit
 


### PR DESCRIPTION
Normal function calls and variadic functions have a different ABI on PowerPC compared to x86 and ARM.

The definition of `sprintf` generated by the labrys compiler in the examples (e.g. `examples/Nat.sfw`) was typically:
```
declare void @sprintf(i8*, i8*, i32)
```
whereas it should have been:
```
declare void @sprintf(i8*, i8*, ...)
```
The LLVM code generation produces working code when non-optimized (`Llvm_target.CodeGenOptLevel.None`, a.k.a `-O0`) but make the code segfault when using `Llvm_target.CodeGenOptLevel.Less`, a.k.a `-O1` or above.

Big thanks to @rrika for all the major help debugging this thing.