### PR TITLE
Enable type inference for Menhir.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 (version 0.2~)
 
 (cram enable)
-(using menhir 1.0)
+(using menhir 2.0)
 (using dune_site 0.1)
 (formatting disabled)
 


### PR DESCRIPTION
This change is required by Menhir 20211223.