### PR TITLE
Use Utils.PPrint everywhere, never PPrint.

### DIFF
--- a/src/common/err.mli
+++ b/src/common/err.mli
@@ -6,7 +6,7 @@ type t
 exception Exn of t
 
 val fail : loc:Location.t -> ('a, unit, string, 'b) format4 -> 'a
-val fail_doc : loc:Location.t -> PPrint.document -> 'a
+val fail_doc : loc:Location.t -> Utils.PPrint.document -> 'a
 val fail_module : ('a, unit, string, 'b) format4 -> 'a
 
 val dump : t -> string

--- a/src/common/utils.mli
+++ b/src/common/utils.mli
@@ -1,6 +1,13 @@
 (* Copyright (c) 2013-2017 The Labrys developers. *)
 (* See the LICENSE file at the top-level directory. *)
 
+module PPrint : sig
+  include module type of PPrint
+
+  val str : string -> document
+  val (^^^) : document -> document -> document
+end
+
 val string_of_uchar : Uchar.t -> string
 
 val string_of_doc : PPrint.document -> string
@@ -22,9 +29,3 @@ val exec_command : string -> string list -> int
 
 module CCIO : module type of CCIO
 
-module PPrint : sig
-  include module type of PPrint
-
-  val str : string -> document
-  val (^^^) : document -> document -> document
-end


### PR DESCRIPTION
This guarantees compatibility with PPrint 20220102.